### PR TITLE
Fix `join` order

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ export function toMarkdown(tree, options = {}) {
   configure(context, options)
 
   if (context.options.tightDefinitions) {
-    context.join.unshift(joinDefinition)
+    configure(context, {join: [joinDefinition]})
   }
 
   /** @type {Handle} */

--- a/lib/util/container-flow.js
+++ b/lib/util/container-flow.js
@@ -40,7 +40,7 @@ export function containerFlow(parent, context) {
     /** @type {ReturnType<Join>} */
     let result
 
-    while (--index >= 0) {
+    while (index--) {
       result = context.join[index](left, right, parent, context)
 
       if (result === true || result === 1) {

--- a/lib/util/container-flow.js
+++ b/lib/util/container-flow.js
@@ -36,11 +36,11 @@ export function containerFlow(parent, context) {
    * @returns {string}
    */
   function between(left, right) {
-    let index = -1
+    let index = context.join.length
     /** @type {ReturnType<Join>} */
     let result
 
-    while (++index < context.join.length) {
+    while (--index >= 0) {
       result = context.join[index](left, right, parent, context)
 
       if (result === true || result === 1) {

--- a/test/index.js
+++ b/test/index.js
@@ -2700,6 +2700,70 @@ test('escape', (t) => {
     'should support empty `join`, `handlers`, `extensions` in an extension (coverage)'
   )
 
+
+  t.equal(
+    to(
+      {
+        "type": "root",
+        "children": [
+            {
+                "type": "list",
+                "ordered": true,
+                "start": 1,
+                "spread": false,
+                "children": [
+                    {
+                        "type": "listItem",
+                        "spread": true,
+                        "checked": null,
+                        "children": [
+                            {
+                                "type": "paragraph",
+                                "children": [
+                                    {
+                                        "type": "text",
+                                        "value": "foo"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "list",
+                                "ordered": false,
+                                "start": null,
+                                "spread": false,
+                                "children": [
+                                    {
+                                        "type": "listItem",
+                                        "spread": false,
+                                        "checked": null,
+                                        "children": [
+                                            {
+                                                "type": "paragraph",
+                                                "children": [
+                                                    {
+                                                        "type": "text",
+                                                        "value": "bar"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+      {
+        join: [() => 0],
+      }
+    ),
+    '1.  foo\n    *   bar\n',
+    'should make `join` from options highest priority'
+  )
+
   t.equal(
     to(
       {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`join` from options should have a higher priority. It's useful for handling list/listItem spread logic.

<!--do not edit: pr-->
