### PR TITLE
Fix to not add superfluous spaces for code (text)

### DIFF
--- a/lib/handle/inline-code.js
+++ b/lib/handle/inline-code.js
@@ -27,8 +27,7 @@ export function inlineCode(node, _, context) {
   // first or last character are a space, eol, or tick, then pad with spaces.
   if (
     /[^ \r\n]/.test(value) &&
-    (/[ \r\n`]/.test(value.charAt(0)) ||
-      /[ \r\n`]/.test(value.charAt(value.length - 1)))
+    ((/^[ \r\n]/.test(value) && /[ \r\n]$/.test(value)) || /^`|`$/.test(value))
   ) {
     value = ' ' + value + ' '
   }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@types/mdast": "^3.0.0",
-    "@types/unist": "^2.0.0",
+    "@types/mdast": "3.0.3",
+    "@types/unist": "2.0.4",
     "longest-streak": "^3.0.0",
     "mdast-util-to-string": "^3.0.0",
     "parse-entities": "^3.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1437,15 +1437,21 @@ test('Code text', (t) => {
   )
 
   t.equal(
+    to({type: 'inlineCode', value: ' a '}),
+    '`  a  `\n',
+    'should pad w/ a space if the value starts and ends w/ a space'
+  )
+
+  t.equal(
     to({type: 'inlineCode', value: ' a'}),
-    '`  a `\n',
-    'should pad w/ a space if the value starts w/ a space'
+    '` a`\n',
+    'should not pad w/ spaces if the value ends w/ a non-space'
   )
 
   t.equal(
     to({type: 'inlineCode', value: 'a '}),
-    '` a  `\n',
-    'should pad w/ a space if the value ends w/ a space'
+    '`a `\n',
+    'should not pad w/ spaces if the value starts w/ a non-space'
   )
 
   t.equal(
@@ -1462,7 +1468,7 @@ test('Code text', (t) => {
 
   t.equal(
     to({type: 'inlineCode', value: 'a\n1. '}),
-    '` a 1.  `\n',
+    '`a 1. `\n',
     'should prevent breaking out of code (\\d\\.)'
   )
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Ref: https://github.com/syntax-tree/unist/discussions/46#discussioncomment-921609

<!--do not edit: pr-->
