### PR TITLE
Fix user handlers erases extension handlers

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -28,7 +28,7 @@ export function configure(base, extension) {
       // @ts-expect-error: hush.
       base[key] = [...(base[key] || []), ...(extension[key] || [])]
     } else if (key === 'handlers') {
-      base[key] = Object.assign(base[key], extension[key] || {})
+      base[key] = {...base[key], ...(extension[key] || {})}
     } else {
       // @ts-expect-error: hush.
       base.options[key] = extension[key]


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [X] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [X] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [X] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [X] If applicable, I’ve added docs and tests

### Description of changes

This fixes the case where a user defines handlers and extensions that also define more handlers.

User handlers and extension handlers will be merged together and only extension handlers with the same type name as user handlers will be overriden.

I haven't added any unit test because there is no public API to read the options.

Maybe in the future we could add a way to read the options so we can test that the merge is done correctly?

For more infornmation: GH-39

<!--do not edit: pr-->
