### PR TITLE
Fix roundtripping attention-like underscores

### DIFF
--- a/lib/unsafe.js
+++ b/lib/unsafe.js
@@ -96,8 +96,7 @@ export const unsafe = [
   // Caret is not used in markdown for constructs.
   // An underscore can start emphasis, strong, or a thematic break.
   {atBreak: true, character: '_'},
-  {before: '[^A-Za-z]', character: '_', inConstruct: 'phrasing'},
-  {character: '_', after: '[^A-Za-z]', inConstruct: 'phrasing'},
+  {character: '_', inConstruct: 'phrasing'},
   // A grave accent can start code (fenced or text), or it can break out of
   // a grave accent code fence.
   {atBreak: true, character: '`'},

--- a/test/index.js
+++ b/test/index.js
@@ -3585,5 +3585,75 @@ test('roundtrip', (t) => {
     'should roundtrip encoded spaces and tabs where needed'
   )
 
+  doc = `Separate paragraphs:
+
+a * is this emphasis? *
+
+a ** is this emphasis? **
+
+a *** is this emphasis? ***
+
+a *\\* is this emphasis? *\\*
+
+a \\** is this emphasis? \\**
+
+a **\\* is this emphasis? **\\*
+
+a *\\** is this emphasis? *\\**
+
+One paragraph:
+
+a * is this emphasis? *
+a ** is this emphasis? **
+a *** is this emphasis? ***
+a *\\* is this emphasis? *\\*
+a \\** is this emphasis? \\**
+a **\\* is this emphasis? **\\*
+a *\\** is this emphasis? *\\**`
+  tree = from(doc)
+
+  t.deepEqual(
+    removePosition(tree, true),
+    removePosition(from(to(tree)), true),
+    'should roundtrip asterisks (tree)'
+  )
+
+  doc = `Separate paragraphs:
+
+a _ is this emphasis? _
+
+a __ is this emphasis? __
+
+a ___ is this emphasis? ___
+
+a _\\_ is this emphasis? _\\_
+
+a \\__ is this emphasis? \\__
+
+a __\\_ is this emphasis? __\\_
+
+a _\\__ is this emphasis? _\\__
+
+One paragraph:
+
+a _ is this emphasis? _
+a __ is this emphasis? __
+a ___ is this emphasis? ___
+a _\\_ is this emphasis? _\\_
+a \\__ is this emphasis? \\__
+a __\\_ is this emphasis? __\\_
+a _\\__ is this emphasis? _\\__`
+  tree = from(doc)
+
+  t.deepEqual(
+    removePosition(tree, true),
+    removePosition(from(to(tree)), true),
+    'should roundtrip underscores (tree)'
+  )
+
+  doc = to(from(`(____`))
+
+  t.equal(doc, to(from(doc)), 'should roundtrip attention-like plain text')
+
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -3655,5 +3655,11 @@ a _\\__ is this emphasis? _\\__`
 
   t.equal(doc, to(from(doc)), 'should roundtrip attention-like plain text')
 
+  doc = to(
+    from('Once activated, a service worker ______, then transitions to idle…')
+  )
+
+  t.equal(doc, to(from(doc)), 'should roundtrip faux “fill in the blank” spans')
+
   t.end()
 })


### PR DESCRIPTION
Related to GH-25.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This solves roundtripping underscores by escaping *all* of them (same as for asterisks).

<!--do not edit: pr-->
