### PR TITLE
Fix collapsed link references containing inline code

### DIFF
--- a/lib/handle/link-reference.js
+++ b/lib/handle/link-reference.js
@@ -30,7 +30,12 @@ export function linkReference(node, _, context) {
   context.stack = stack
   exit()
 
-  if (type === 'full' || !text || text !== reference) {
+  if (
+    type === 'full' ||
+    !text ||
+    (text !== reference &&
+      node.children.every((node) => node.type !== 'inlineCode'))
+  ) {
     value += '[' + reference + ']'
   } else if (type !== 'shortcut') {
     value += '[]'

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,100 @@ test('core', (t) => {
     to({
       type: 'root',
       children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'linkReference',
+              children: [
+                {
+                  type: 'inlineCode',
+                  value: 'code',
+                  position: {
+                    start: {
+                      line: 1,
+                      column: 2,
+                      offset: 1
+                    },
+                    end: {
+                      line: 1,
+                      column: 8,
+                      offset: 7
+                    }
+                  }
+                }
+              ],
+              position: {
+                start: {
+                  line: 1,
+                  column: 1,
+                  offset: 0
+                },
+                end: {
+                  line: 1,
+                  column: 11,
+                  offset: 10
+                }
+              },
+              identifier: '`code`',
+              label: 'code',
+              referenceType: 'collapsed'
+            }
+          ],
+          position: {
+            start: {
+              line: 1,
+              column: 1,
+              offset: 0
+            },
+            end: {
+              line: 1,
+              column: 11,
+              offset: 10
+            }
+          }
+        },
+        {
+          type: 'definition',
+          identifier: '`code`',
+          label: '`code`',
+          title: null,
+          url: 'about:blank',
+          position: {
+            start: {
+              line: 3,
+              column: 1,
+              offset: 12
+            },
+            end: {
+              line: 3,
+              column: 22,
+              offset: 33
+            }
+          }
+        }
+      ],
+      position: {
+        start: {
+          line: 1,
+          column: 1,
+          offset: 0
+        },
+        end: {
+          line: 4,
+          column: 1,
+          offset: 34
+        }
+      }
+    }),
+    '[`code`][]\n\n[`code`]: about:blank\n',
+    'should support inline code inside link references'
+  )
+
+  t.equal(
+    to({
+      type: 'root',
+      children: [
         {type: 'paragraph', children: [{type: 'text', value: 'a'}]},
         // @ts-expect-error: `identifier`, `url` missing.
         {type: 'definition', label: 'b'},


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Currently a markdown document looking like:

```markdown
[`code`][]

[`code`]: about:blank
```

Is transformed into:

```markdown
[`code`][code]

[`code`]: about:blank
```

Which doesn't work because there's no `[code]` definition (and even worse, if there's one, the link now links to something else).

My suggested change is probably too naive, but at least tests are passing.

<!--do not edit: pr-->
