### PR TITLE
Don't escape plus not followed by a whitespace

### DIFF
--- a/lib/unsafe.js
+++ b/lib/unsafe.js
@@ -88,7 +88,7 @@ export const unsafe = [
   {atBreak: true, character: '*'},
   {character: '*', inConstruct: 'phrasing', notInConstruct: fullPhrasingSpans},
   // A plus sign could start a list item.
-  {atBreak: true, character: '+'},
+  {atBreak: true, character: '+', after: '(?:[ \t\r\n])'},
   // A dash can start thematic breaks, list items, and setext heading
   // underlines.
   {atBreak: true, character: '-'},

--- a/test/index.js
+++ b/test/index.js
@@ -3032,6 +3032,12 @@ test('escape', (t) => {
   )
 
   t.equal(
+    to({type: 'paragraph', children: [{type: 'text', value: '+a'}]}),
+    '+a\n',
+    'should not escape a `+` if it is not followed by a whitespace'
+  )
+
+  t.equal(
     to({
       type: 'paragraph',
       children: [


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR improves the escape unsafe rule for `+`. If a `+` is not followed by `[\ \t\r\n]`, then it won't turn into a list item, thus we don't need to escape it. 






<!--do not edit: pr-->
