### PR TITLE
encode less-than signs in text context after whitespace

### DIFF
--- a/lib/unsafe.js
+++ b/lib/unsafe.js
@@ -109,6 +109,12 @@ export const unsafe = [
     inConstruct: 'phrasing',
     notInConstruct: fullPhrasingSpans
   },
+  {
+    character: '<',
+    before: '(?:[ \t\r\n]|$)',
+    inConstruct: 'phrasing',
+    notInConstruct: fullPhrasingSpans
+  },
   {character: '<', inConstruct: 'destinationLiteral'},
   // An equals to can start setext heading underlines.
   {atBreak: true, character: '='},

--- a/test/index.js
+++ b/test/index.js
@@ -3933,6 +3933,26 @@ test('escape', async function (t) {
   })
 
   await t.test(
+    'should escape what would otherwise be html (2)',
+    async function () {
+      assert.equal(
+        to({type: 'paragraph', children: [{type: 'text', value: '<1%'}]}),
+        '\\<1%\n'
+      )
+    }
+  )
+
+  await t.test(
+    'dont escape a less-than sign that cant be a tag open',
+    async function () {
+      assert.equal(
+        to({type: 'paragraph', children: [{type: 'text', value: 'm<1%'}]}),
+        'm<1%\n'
+      )
+    }
+  )
+
+  await t.test(
     'should escape what would otherwise be code (text)',
     async function () {
       assert.equal(


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

I found a case using remark-cli/remark-lint/remark-stringify where a bare `<` was getting emitted as markdown when inside of a list and causing rendering problems. This adds a test case to this and adds a definition in unsafe.js to prevent this from happening.

I'm not sure this is the minimal set of unsafe conditions- it does seem to catch my case and not some other cases where a new escape would be annoying, but I haven't really been exhaustive in searching, relying mostly on the existing test suite.

<!--do not edit: pr-->
