### PR TITLE
fix: do not escape underscore inside of words

### DIFF
--- a/lib/unsafe.js
+++ b/lib/unsafe.js
@@ -130,7 +130,18 @@ export const unsafe = [
   // Caret is not used in markdown for constructs.
   // An underscore can start emphasis, strong, or a thematic break.
   {atBreak: true, character: '_'},
-  {character: '_', inConstruct: 'phrasing', notInConstruct: fullPhrasingSpans},
+  {
+    character: '_',
+    before: '[\\s]',
+    inConstruct: 'phrasing',
+    notInConstruct: fullPhrasingSpans
+  },
+  {
+    character: '_',
+    after: '[\\s]',
+    inConstruct: 'phrasing',
+    notInConstruct: fullPhrasingSpans
+  },
   // A grave accent can start code (fenced or text), or it can break out of
   // a grave accent code fence.
   {atBreak: true, character: '`'},

--- a/test/index.js
+++ b/test/index.js
@@ -4537,9 +4537,28 @@ test('roundtrip', async function (t) {
   })
 
   await t.test(
-    'should roundtrip underscore inside of words',
+    'should roundtrip underscore without escaping',
     async function () {
-      const value = 'HELLO_WORLD https://some/web_site\n'
+      const value = `Separate paragraphs:
+
+HELLO_WORLD https://some/web_site
+
+HELLO_WORLD. HELLO_WORLD, H_W; HELLO_OTHER! HELLO_YES? HELLO_NO
+
+HELLO_WORLD.HELLO_WORLD,H_W;HELLO_OTHER!HELLO_YES?HELLO_NO
+
+HELLO_WORLD - THIS_GOOD
+
+HELLO_WORLD-THIS_GOOD
+
+One Paragraph:
+
+HELLO_WORLD https://some/web_site
+HELLO_WORLD. HELLO_WORLD, H_W; HELLO_OTHER! HELLO_YES? HELLO_NO
+HELLO_WORLD.HELLO_WORLD,H_W;HELLO_OTHER!HELLO_YES?HELLO_NO
+HELLO_WORLD - THIS_GOOD
+HELLO_WORLD-THIS_GOOD
+`
 
       assert.equal(to(from(value)), value)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -4848,6 +4848,20 @@ a __\\_ is this emphasis? __\\_
 
 a _\\__ is this emphasis? _\\__
 
+a _ is_this emphasis? _
+
+a __ is_this emphasis? __
+
+a ___ is_this emphasis? ___
+
+a _\\_ is_this emphasis? _\\_
+
+a \\__ is_this emphasis? \\__
+
+a __\\_ is_this emphasis? __\\_
+
+a _\\__ is_this emphasis? _\\__
+
 One paragraph:
 
 a _ is this emphasis? _
@@ -4856,7 +4870,15 @@ a ___ is this emphasis? ___
 a _\\_ is this emphasis? _\\_
 a \\__ is this emphasis? \\__
 a __\\_ is this emphasis? __\\_
-a _\\__ is this emphasis? _\\__`
+a _\\__ is this emphasis? _\\__
+
+a _ is_this emphasis? _
+a __ is_this emphasis? __
+a ___ is_this emphasis? ___
+a _\\_ is_this emphasis? _\\_
+a \\__ is_this emphasis? \\__
+a __\\_ is_this emphasis? __\\_
+a _\\__ is_this emphasis? _\\__`
     const tree = from(value)
 
     assert.deepEqual(

--- a/test/index.js
+++ b/test/index.js
@@ -3895,6 +3895,39 @@ test('escape', async function (t) {
     }
   )
 
+  await t.test('should escape underscore at word start', async function () {
+    assert.equal(
+      to({
+        type: 'paragraph',
+        children: [{type: 'text', value: '_WORLD'}]
+      }),
+      '\\_WORLD\n'
+    )
+  })
+
+  await t.test('should escape underscore at word end', async function () {
+    assert.equal(
+      to({
+        type: 'paragraph',
+        children: [{type: 'text', value: 'HELLO_'}]
+      }),
+      'HELLO\\_\n'
+    )
+  })
+
+  await t.test(
+    'should not escape underscore inside of word',
+    async function () {
+      assert.equal(
+        to({
+          type: 'paragraph',
+          children: [{type: 'text', value: 'HELLO_WORLD'}]
+        }),
+        'HELLO_WORLD\n'
+      )
+    }
+  )
+
   await t.test(
     'should escape what would otherwise be a heading (atx)',
     async function () {
@@ -4502,6 +4535,15 @@ test('roundtrip', async function (t) {
       removePosition(from(to(from(value))))
     )
   })
+
+  await t.test(
+    'should roundtrip underscore inside of words',
+    async function () {
+      const value = 'HELLO_WORLD https://some/web_site\n'
+
+      assert.equal(to(from(value)), value)
+    }
+  )
 
   await t.test(
     'should roundtrip a sole blank line in fenced code',

--- a/test/index.js
+++ b/test/index.js
@@ -4541,6 +4541,10 @@ test('roundtrip', async function (t) {
     async function () {
       const value = `Separate paragraphs:
 
+:heavy_check_mark:
+
+[HELLO_WORLD.md](HELLO_WORLD.md)
+
 HELLO_WORLD https://some/web_site
 
 HELLO_WORLD. HELLO_WORLD, H_W; HELLO_OTHER! HELLO_YES? HELLO_NO
@@ -4553,6 +4557,8 @@ HELLO_WORLD-THIS_GOOD
 
 One Paragraph:
 
+:heavy_check_mark:
+[HELLO_WORLD.md](HELLO_WORLD.md)
 HELLO_WORLD https://some/web_site
 HELLO_WORLD. HELLO_WORLD, H_W; HELLO_OTHER! HELLO_YES? HELLO_NO
 HELLO_WORLD.HELLO_WORLD,H_W;HELLO_OTHER!HELLO_YES?HELLO_NO


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

As commented in https://github.com/remarkjs/remark/issues/1455#issuecomment-3724812006 underscores inside of words are fine in commonmark, i.e. `HELLO_WORLD` or `https://raw/links_with_underscore` should not be escaped.

This PR makes escape rules for `_` more specific to prevent unnecessary escaping inside of words such as HELLO_WORLD or urls (https://some/web_site).

Related to https://github.com/remarkjs/remark/issues/1455

<!--do not edit: pr-->
